### PR TITLE
Fix parsing error by removing redundant field

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,6 @@ Authors@R: c(
            family = "Heß",
            role = "ctb")
            )
-Maintainer: <contact@grantmcdermott.com>
 Description: An experimental port of the `ritest` Stata routine by Simon Heß.
     Fast and user-friendly. Aims to support a variety of model classes once it 
     is fully baked.


### PR DESCRIPTION
The syntax of this field is wrong (it should be `name <email>`) however it is also redundant because you already name the maintainer in the `Authors@R` field. 

Fixes https://github.com/r-universe/grantmcdermott/actions/runs/28701731917/job/85120790234